### PR TITLE
Exit cleanly from Control-C

### DIFF
--- a/lib/filewatcher.rb
+++ b/lib/filewatcher.rb
@@ -31,7 +31,11 @@ class FileWatcher
 
   def watch(sleep=1, &on_update)
     loop do
-      Kernel.sleep sleep until file_updated?
+      begin
+        Kernel.sleep sleep until file_updated?
+      rescue SystemExit,Interrupt
+        Kernel.exit
+      end
       yield @updated_file
     end
   end


### PR DESCRIPTION
This prevents a stack trace from printing on exit
