### PR TITLE
Added pause/resume/end watch and finalize, with tests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,29 @@ for syntax.
       puts "Updated " + filename
     end
 
-The filewatcher library is just a single file with 96 LOC (including comments)
+Start, pause, resume, stop, and finalize a running watch. This is particularly
+useful when the update block takes a while to process each file (eg. sending
+over the network)
+
+    filewatcher = FileWatcher.new(["*.rb"])
+    thread = Thread.new(filewatcher){|fw| fw.watch{|f| puts "Updated " + f}}
+      ...
+    filewatcher.pause_watch # block stops responding to filesystem changes
+    filewatcher.finalize    # Ensure all filesystem changes made prior to
+                            # pausing are handled.
+      ...
+    filewatcher.resume_watch # block begins responding again, but is not given
+                             # changes made between #pause_watch and
+                             # #resume_watch
+      ...
+    filewatcher.end_watch  # block stops responding to filesystem changes
+                           # and takes a final snapshot of the filesystem
+    thread.join
+
+    filewatcher.finalize   # Ensure all filesystem changes made prior to
+                           # ending the watch are handled.
+
+The filewatcher library is just a single file with 123 LOC (including comments)
 with no dependencies.
 
 

--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ over the network)
     filewatcher.finalize   # Ensure all filesystem changes made prior to
                            # ending the watch are handled.
 
-The filewatcher library is just a single file with 123 LOC (including comments)
+The filewatcher library is just a single file with 147 LOC (including comments)
 with no dependencies.
 
 

--- a/bin/filewatcher
+++ b/bin/filewatcher
@@ -30,9 +30,10 @@ EOS
   opt :include, "Include files", :type => :string, :default => "*"
   opt :exclude, "Exclude file(s) matching", :type => :string, :default => ""
   opt :interval, "Interval to scan filesystem.", :short => 'i', :type => :float, :default => 0.5
+  opt :quiet, "Hide spinner", :short => 'q', :type => :boolean, :default => false
 end
 
-Trollop::die "must have at least one argument" if(ARGV.size == 0)
+Trollop::die Trollop::educate if(ARGV.size == 0)
 
 files = []
 ARGV[0...-1].each do |a|
@@ -59,37 +60,13 @@ end
 
 files = split_files_void_escaped_whitespace(files)
 
-def fork_process(env, cmd)
-  pipe_read, pipe_write = IO.pipe
-  fork do
-    pipe_read.close
-    pipe_write.write Process.spawn(env,cmd).to_s
-    exit
-  end
-
-  Kernel.sleep 1
-  pipe_write.close
-  child_pid = pipe_read.read.to_i
-  pipe_read.close
-  return child_pid
-end
-
-def kill_process(child_pid)
-  still_running = true
-  begin
-    Process.kill(9, child_pid)
-  rescue Errno::ESRCH
-    still_running = false
-  end
-  while still_running do
-    begin
-      Process.getpgid( child_pid)
-      still_running = true
-    rescue Errno::ESRCH
-      still_running = false
-    end
-    Kernel.sleep 0.1
-  end
+def restart(child_pid, env, cmd)
+  Process.kill(9,child_pid)
+  Process.wait(child_pid)
+rescue Errno::ESRCH
+  # already killed
+ensure
+  child_pid = Process.spawn(env, cmd)
 end
 
 if(options[:restart])
@@ -98,7 +75,7 @@ if(options[:restart])
 end
 
 begin
-  fw = FileWatcher.new(files, options[:list], options[:dontwait])
+  fw = FileWatcher.new(files, options[:list], options[:dontwait], !options[:quiet])
   fw.watch(options[:interval]) do |filename, event|
     cmd = nil
     if(options[:exec] and File.exist?(filename))
@@ -137,10 +114,9 @@ begin
 
       if(options[:restart])
         if(child_pid == nil)
-          child_pid = fork_process(env, cmd)
+          child_pid = Process.spawn(env, cmd)
         else
-          kill_process(child_pid)
-          child_pid = fork_process(env, cmd)
+          child_id = restart(child_pid, env, cmd)
         end
       else
         begin

--- a/bin/filewatcher
+++ b/bin/filewatcher
@@ -97,70 +97,75 @@ if(options[:restart])
   child_pid = nil
 end
 
-FileWatcher.new(files, options[:list], options[:dontwait]).watch(options[:interval]) do |filename, event|
-  cmd = nil
-  if(options[:exec] and File.exist?(filename))
-    extension = filename[/(\.[^\.]*)$/,0]
-    runners = {
-      ".py" => "python",
-      ".js" => "node",
-      ".rb" => "ruby",
-      ".pl" => "perl",
-      ".awk" => "awk",
-      ".php" => "php",
-      ".phtml" => "php",
-      ".php4" => "php",
-      ".php3" => "php",
-      ".php5" => "php",
-      ".phps" => "php"
-    }
-    runner = runners[extension]
-    if(runner)
-      cmd = "env #{runner.to_s} #{filename}"
-    end
-  elsif(ARGV.length > 1)
-    cmd = ARGV[-1]
-  end
-
-  if(cmd)
-    path = Pathname.new(filename)
-    env = {
-      'FILENAME'=> path.to_s,
-      'FILEDIR' => path.parent.realpath.to_s,
-      'FSEVENT' => event.to_s
-    }
-    if(event != :delete)
-      ENV['FILEPATH'] = path.realpath.to_s
+begin
+  fw = FileWatcher.new(files, options[:list], options[:dontwait])
+  fw.watch(options[:interval]) do |filename, event|
+    cmd = nil
+    if(options[:exec] and File.exist?(filename))
+      extension = filename[/(\.[^\.]*)$/,0]
+      runners = {
+        ".py" => "python",
+        ".js" => "node",
+        ".rb" => "ruby",
+        ".pl" => "perl",
+        ".awk" => "awk",
+        ".php" => "php",
+        ".phtml" => "php",
+        ".php4" => "php",
+        ".php3" => "php",
+        ".php5" => "php",
+        ".phps" => "php"
+      }
+      runner = runners[extension]
+      if(runner)
+        cmd = "env #{runner.to_s} #{filename}"
+      end
+    elsif(ARGV.length > 1)
+      cmd = ARGV[-1]
     end
 
-    if(options[:restart])
-      if(child_pid == nil)
-        child_pid = fork_process(env, cmd)
+    if(cmd)
+      path = Pathname.new(filename)
+      env = {
+        'FILENAME'=> path.to_s,
+        'FILEDIR' => path.parent.realpath.to_s,
+        'FSEVENT' => event.to_s
+      }
+      if(event != :delete)
+        ENV['FILEPATH'] = path.realpath.to_s
+      end
+
+      if(options[:restart])
+        if(child_pid == nil)
+          child_pid = fork_process(env, cmd)
+        else
+          kill_process(child_pid)
+          child_pid = fork_process(env, cmd)
+        end
       else
-        kill_process(child_pid)
-        child_pid = fork_process(env, cmd)
+        begin
+          pid = Process.spawn(env, cmd)
+          Process.wait()
+        rescue SystemExit, Interrupt
+          exit(0)
+        end
       end
+
     else
-      begin
-        pid = Process.spawn(env, cmd)
-        Process.wait()
-      rescue SystemExit, Interrupt
-        exit(0)
+      case(event)
+      when :changed
+        print "file updated"
+      when :delete
+        print "file deleted"
+      when :new
+        print "new file"
+      else
+        print event.to_s
       end
+      puts ": " + filename
     end
 
-  else
-    case(event)
-    when :changed
-      print "file updated"
-    when :delete
-      print "file deleted"
-    when :new
-      print "new file"
-    else
-      print event.to_s
-    end
-    puts ": " + filename
   end
-
+rescue SystemExit, Interrupt
+  fw.finalize
 end

--- a/lib/filewatcher.rb
+++ b/lib/filewatcher.rb
@@ -79,6 +79,7 @@ class FileWatcher
   # Used mainly in multi-threaded situations.
   def stop
     @keep_watching = false
+    update_spinner('Stopping')
     return nil
   end
 

--- a/lib/filewatcher.rb
+++ b/lib/filewatcher.rb
@@ -35,7 +35,7 @@ class FileWatcher
     while @keep_watching
       @end_snapshot = mtime_snapshot if @pausing
       while @keep_watching && @pausing
-        Kernel.sleep 1
+        Kernel.sleep sleep
       end
       while @keep_watching && !filesystem_updated? && !@pausing
         Kernel.sleep sleep

--- a/test/test_filewatcher.rb
+++ b/test/test_filewatcher.rb
@@ -100,8 +100,8 @@ describe FileWatcher do
 
   it "should be stoppable" do
     filewatcher = FileWatcher.new(["test/fixtures"])
-    thread = Thread.new(filewatcher){filewatcher.watch}
-    sleep 1  # thread needs a chance to start
+    thread = Thread.new(filewatcher){filewatcher.watch(0.1)}
+    sleep 0.2  # thread needs a chance to start
     filewatcher.end_watch
     thread.join.should.equal thread # Proves thread successfully joined
   end
@@ -111,24 +111,24 @@ describe FileWatcher do
     filewatcher.filesystem_updated?.should.be.false
     processed = []
     thread = Thread.new(filewatcher,processed) do
-      filewatcher.watch{|f| processed << f }
+      filewatcher.watch(0.1){|f| processed << f }
     end
-    sleep 0.5  # thread needs a chance to start
+    sleep 0.2  # thread needs a chance to start
     filewatcher.pause_watch
     (1..4).each do |n|
       open("test/fixtures/file#{n}.txt","w") { |f| f.puts "content#{n}" }
     end
-    sleep 1 # Give filewatcher time to respond
+    sleep 0.2 # Give filewatcher time to respond
     processed.should.equal []  #update block should not have been called
     filewatcher.resume_watch
-    sleep 1 # Give filewatcher time to respond
+    sleep 0.2 # Give filewatcher time to respond
     processed.should.equal []  #update block still should not have been called
     added_files = []
     (5..7).each do |n|
       added_files << "test/fixtures/file#{n}.txt"
       open(added_files.last,"w") { |f| f.puts "content#{n}" }
     end
-    sleep 1 # Give filewatcher time to respond
+    sleep 0.2 # Give filewatcher time to respond
     filewatcher.end_watch
     processed.should.satisfy &includes_all(added_files)
   end
@@ -138,9 +138,9 @@ describe FileWatcher do
     filewatcher.filesystem_updated?.should.be.false
     processed = []
     thread = Thread.new(filewatcher,processed) do
-      filewatcher.watch{|f| processed << f }
+      filewatcher.watch(0.1){|f| processed << f }
     end
-    sleep 1  # thread needs a chance to start
+    sleep 0.2  # thread needs a chance to start
     filewatcher.end_watch
     thread.join
     added_files = []

--- a/test/test_filewatcher.rb
+++ b/test/test_filewatcher.rb
@@ -111,7 +111,7 @@ describe FileWatcher do
     filewatcher.filesystem_updated?.should.be.false
     processed = []
     thread = Thread.new(filewatcher,processed) do
-      filewatcher.watch(0.1){|f| processed << f }
+      filewatcher.watch(0.1){|f,e| processed << f }
     end
     sleep 0.2  # thread needs a chance to start
     filewatcher.pause_watch
@@ -138,7 +138,7 @@ describe FileWatcher do
     filewatcher.filesystem_updated?.should.be.false
     processed = []
     thread = Thread.new(filewatcher,processed) do
-      filewatcher.watch(0.1){|f| processed << f }
+      filewatcher.watch(0.1){|f,e| processed << f }
     end
     sleep 0.2  # thread needs a chance to start
     filewatcher.end_watch

--- a/test/test_filewatcher.rb
+++ b/test/test_filewatcher.rb
@@ -102,7 +102,7 @@ describe FileWatcher do
     filewatcher = FileWatcher.new(["test/fixtures"])
     thread = Thread.new(filewatcher){filewatcher.watch(0.1)}
     sleep 0.2  # thread needs a chance to start
-    filewatcher.end_watch
+    filewatcher.stop
     thread.join.should.equal thread # Proves thread successfully joined
   end
 
@@ -114,13 +114,13 @@ describe FileWatcher do
       filewatcher.watch(0.1){|f,e| processed << f }
     end
     sleep 0.2  # thread needs a chance to start
-    filewatcher.pause_watch
+    filewatcher.pause
     (1..4).each do |n|
       open("test/fixtures/file#{n}.txt","w") { |f| f.puts "content#{n}" }
     end
     sleep 0.2 # Give filewatcher time to respond
     processed.should.equal []  #update block should not have been called
-    filewatcher.resume_watch
+    filewatcher.resume
     sleep 0.2 # Give filewatcher time to respond
     processed.should.equal []  #update block still should not have been called
     added_files = []
@@ -129,7 +129,7 @@ describe FileWatcher do
       open(added_files.last,"w") { |f| f.puts "content#{n}" }
     end
     sleep 0.2 # Give filewatcher time to respond
-    filewatcher.end_watch
+    filewatcher.stop
     processed.should.satisfy &includes_all(added_files)
   end
 
@@ -141,7 +141,7 @@ describe FileWatcher do
       filewatcher.watch(0.1){|f,e| processed << f }
     end
     sleep 0.2  # thread needs a chance to start
-    filewatcher.end_watch
+    filewatcher.stop
     thread.join
     added_files = []
     (1..4).each do |n|

--- a/test/test_filewatcher.rb
+++ b/test/test_filewatcher.rb
@@ -149,6 +149,9 @@ describe FileWatcher do
       open(added_files.last,"w") { |f| f.puts "content#{n}" }
     end
     filewatcher.finalize
+    puts "What is wrong with finalize:"
+    puts "Expect: #{added_files.inspect}"
+    puts "Actual: #{processed.inspect}"
     processed.should.satisfy &includes_all(added_files)
   end
 


### PR DESCRIPTION
This allows a single FileWatcher instance (Ruby API) to be started, paused, resumed, ended, and finalized.

I hesitated about issuing a pull request for this series of commits for the following reasons:
* It adds 46 lines to a codebase of just over 100 lines, so it's by no means a "minor" change. I hate to "bloat up" a small, well-written project.
* It (slightly) complicates the logic in `#watch`
* It contains a complete re-write of `#filesystem_updated?` (Not to worry: spec tests still pass)
* Pause/resume/end are probably atypical use cases. They are very useful in a project I'm currently working on, but unlikely to be high on most people's feature requests.
* The features add roughly 3 seconds to the test suite. (Not horrible, but not great either)

Sounds pretty bad! But I decided to go ahead with a pull request because:
* The extra features may justify the extra code.
* Without `#finalize`, there's no way to ensure client code has a chance to handle existing filesystem changes at application shutdown. IMHO it was begging to be implemented.
* My use of hashed snapshots simplifies the logic in `#filesystem_updated?`. To me anyway.

Even if you decide not to merge the pull request, I thought you'd find the snapshotting and diffing logic interesting, and the finalize method useful. I would also be willing to trim this down by removing pause and resume logic and issuing a new pull request. That would still leave the benefits of snapshots and finalizing, but would remove most of the extra logic from `#watch`, reduce the LOC count by about 20 lines, and shave a couple seconds off the test suite.