### PR TITLE
Add quoted file path tilde expansion

### DIFF
--- a/lib/filewatcher.rb
+++ b/lib/filewatcher.rb
@@ -165,7 +165,7 @@ class FileWatcher
     if(!patterns.kind_of?Array)
       patterns = [patterns]
     end
-    patterns.map { |it| Dir[fulldepth(it)] }.flatten.uniq
+    patterns.map { |it| Dir[fulldepth(expand_path(it))] }.flatten.uniq
   end
 
   private
@@ -173,6 +173,14 @@ class FileWatcher
   def fulldepth(pattern)
     if File.directory? pattern
       "#{pattern}/**/*"
+    else
+      pattern
+    end
+  end
+
+  def expand_path(pattern)
+    if pattern.start_with?('~')
+      File.expand_path(pattern)
     else
       pattern
     end

--- a/test/test_filewatcher.rb
+++ b/test/test_filewatcher.rb
@@ -62,6 +62,19 @@ describe FileWatcher do
     filewatcher.filenames.should.satisfy &includes_all(explicit_relative_fixtures)
   end
 
+  it "should handle tilde expansion" do
+    filename = File.expand_path('~/file_watcher_1.txt')
+    open(filename, 'w') { |f| f.puts 'content1' }
+
+    filewatcher = FileWatcher.new('~/file_watcher_1.txt')
+
+    begin
+      filewatcher.filenames.should == [filename]
+    ensure
+      FileUtils.rm(filename)
+    end
+  end
+
   it "should detect file deletions" do
     filename = "test/fixtures/file1.txt"
     open(filename,"w") { |f| f.puts "content1" }


### PR DESCRIPTION
# Expected behaviour

```bash
$ filewatcher --list "~/ test/fixtures"
Watching:
 /home/vagrant/sample1.txt
 /home/vagrant/sample0.txt
 test/fixtures/file1.txt
 test/fixtures/file2.txt
 test/fixtures/file3.rb
 test/fixtures/file4.rb
 test/fixtures/subdir
 test/fixtures/subdir/file5.rb
 test/fixtures/subdir/file6.rb
```

# Actual behaviour
```bash
r$ filewatcher --list "~/ test/fixtures"
Watching:
 test/fixtures/file1.txt
 test/fixtures/file2.txt
 test/fixtures/file3.rb
 test/fixtures/file4.rb
 test/fixtures/subdir
 test/fixtures/subdir/file5.rb
 test/fixtures/subdir/file6.rb
```