### PR TITLE
Rake dependency updated to version 11.3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
 
 gem 'trollop',  '~> 2.1.2'
-gem 'rake',     '~> 11.2.2'
+gem 'rake',     '~> 11.3.0'
 gem 'bacon',    '~> 1.2.0'


### PR DESCRIPTION
Changelog [here](https://github.com/ruby/rake/blob/master/History.rdoc).

Breaking changes are not found.