### PR TITLE
Run in daemon mode fixed

### DIFF
--- a/bin/filewatcher
+++ b/bin/filewatcher
@@ -93,7 +93,7 @@ begin
     end
   end
 
-  Process.daemon if options[:daemon]
+  Process.daemon(true, true) if options[:daemon]
 
   fw.watch(options[:interval]) do |filename, event|
     cmd = nil


### PR DESCRIPTION
The first option is to cancel the change chdir to `/`
The second option is to cancel output to `/dev/null`

More info [here](https://ruby-doc.org/core-2.3.1/Process.html#method-c-daemon).

-----

Sorry for the loss of this in #36, it was difficult to test.

I think these flags are necessary.

The first does the job daemon in the current directory, not in root (`/`).

The second provides a choice to the user on the output of `filewatcher`, at least to `/dev/null`, or to file.