### PR TITLE
Fix event names (types)

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ BASENAME           File basename.
 FILENAME           Relative filename.
 ABSOLUTE_FILENAME  Asolute filename.
 RELATIVE_FILENAME  Same as FILENAME but starts with "./"
-EVENT              Event type. Is either 'changed', 'delete' or 'new'.
+EVENT              Event type. Is either 'updated', 'deleted' or 'created'.
 DIRNAME            Absolute directory name.
 ```
 
@@ -211,14 +211,7 @@ To detect if a file is updated, added or deleted:
 
 ```ruby
 FileWatcher.new(['README.rdoc']).watch do |filename, event|
-  case event
-  when :changed
-    puts "File updated: #{filename}"
-  when :delete
-    puts "File deleted: #{filename}"
-  when :new
-    puts "Added file: #{filename}"
-  end
+  puts "File #{event}: #{filename}"
 end
 ```
 

--- a/bin/filewatcher
+++ b/bin/filewatcher
@@ -135,7 +135,7 @@ begin
         'RELATIVE_FILENAME' => File.join('.', path)
       }
 
-      ENV['FILEPATH'] = path.realpath.to_s if event != :delete
+      ENV['FILEPATH'] = path.realpath.to_s if event != :deleted
 
       if options[:restart]
         child_pid =
@@ -154,17 +154,7 @@ begin
       end
 
     else
-      case event
-      when :changed
-        print 'file updated'
-      when :delete
-        print 'file deleted'
-      when :new
-        print 'new file'
-      else
-        print event.to_s
-      end
-      puts ": #{filename}"
+      puts "file #{event}: #{filename}"
     end
   end
 rescue SystemExit, Interrupt

--- a/lib/filewatcher.rb
+++ b/lib/filewatcher.rb
@@ -119,7 +119,7 @@ class FileWatcher
 
     forward_changes.each do |file, mtime|
       @updated_file = file
-      @event = @last_snapshot.fetch(@updated_file, false) ? :changed : :new
+      @event = @last_snapshot.fetch(@updated_file, false) ? :updated : :created
       @last_snapshot[file] = mtime
       return true
     end
@@ -130,7 +130,7 @@ class FileWatcher
     backward_changes.each do |file, _mtime|
       @updated_file = file
       @last_snapshot.delete(file)
-      @event = :delete
+      @event = :deleted
       return true
     end
     false


### PR DESCRIPTION
I propose to adhere to this terminology:

 What happend     |   Event
--------------------- | ----------
 New file found       | `created`
 Known file changed   | `updated`
 Known file not found | `deleted`

And `changed` — any of these changes.

Make sense for writing code to #46.

I also found a `renamed` in the README, but decided not to remove it (for clarity).