### PR TITLE
WIP: Add `--every` option, change default behavior, resolve #46

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,14 @@ In Linux/macOS:
 $ filewatcher '**/*.js' 'node $FILENAME'
 ```
 
+By default, filewatcher executes the command only for the first changed file
+that found from filesystem check, but you can using the `--every/-E` option
+for running the command on each changed file.
+
+```
+$ filewatcher -E * 'echo file: $FILENAME'
+```
+
 Try to run the updated file as a script when it is updated by using the
 `--exec/-e` option. Works with files with file extensions that looks like a
 Python, Ruby, Perl, PHP, JavaScript or AWK script.
@@ -151,6 +159,7 @@ Useful command line options:
         --list, -l:   Print name of matching files on startup
      --restart, -r:   Run command in separate fork and kill it on filesystem updates
    --immediate, -I:   Run the command before any filesystem updates
+       --every, -E:   Run the command for every updated file in one filesystem check
       --daemon, -D:   Run in the background as system daemon
      --spinner, -s:   Display an animated spinner while scanning
 ```

--- a/README.md
+++ b/README.md
@@ -109,6 +109,12 @@ filesystem gets updated:
 $ filewatcher "src test" "ruby test/test_suite.rb"
 ```
 
+Add a delay before the next command execution:
+
+```
+$ filewatcher -d 1.0 * 'echo file: $FILENAME'
+```
+
 ## Restart long running commands
 
 The `--restart/-r` option kills the command if it's still running when
@@ -170,6 +176,7 @@ Other command line options:
      --version, -v:   Print version and exit
         --help, -h:   Show this message
 --interval, -i <f>:   Interval in seconds to scan filesystem, defaults to 0.5 seconds
+   --delay, -d <f>:   Delay in seconds to execute the command again, defaults to 0.0 seconds
         --exec, -e:   Execute file as a script when file is updated
  --include, -n <s>:   Include files (default: *)
  --exclude, -x <s>:   Exclude file(s) matching (default: "")

--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@
 [![Dependency Status](https://gemnasium.com/thomasfl/filewatcher.png?travis)](https://gemnasium.com/thomasfl/filewatcher)
 [![Code Climate](https://codeclimate.com/github/thomasfl/filewatcher.png)](https://codeclimate.com/github/thomasfl/filewatcher)
 
-Lightweight filewatcher weighing less than 200 LoC. No dependencies or platform specific code. Works everywhere. Monitors changes in the filesystem by polling. Has no config files. When running filewatcher from the command line, you specify which files to monitor and what action to perform on updates.
+Lightweight filewatcher weighing less than 350 LoC. No dependencies or platform specific code. Works everywhere. Monitors changes in the filesystem by polling. Has no config files. When running filewatcher from the command line, you specify which files to monitor and what action to perform on updates. Can be runned as daemon (background process).
 
-For example to search recursively for javascript files and run jshint when a file is updated, added, renamed or deleted:
+For example to search recursively for javascript files and run `jshint` when a file is updated, created, renamed or deleted:
 
-Linux/macOS:
+In Linux/macOS:
 
 ```
 $ filewatcher '**/*.js' 'jshint $FILENAME'
@@ -23,7 +23,7 @@ In Windows:
 
 ## Install
 
-Needs Ruby and Rubygems:
+Needs Ruby and RubyGems:
 
 ```
 $ [sudo] gem install filewatcher
@@ -31,8 +31,8 @@ $ [sudo] gem install filewatcher
 
 ## Command line utility
 
-Filewatcher scans the filesystem and execute shell commands when files are
-updated, added, renamed or deleted.
+Filewatcher scans the filesystem and execute a shell command when files are
+updated, created, renamed or deleted.
 
 ```
 Usage:
@@ -46,14 +46,14 @@ Where
 
 ## Examples
 
-Run the echo command when the file myfile is changed:
+Run the `echo` command when the file `myfile` is changed:
 
 ```
 $ filewatcher "myfile" "echo 'myfile has changed'"
 ```
 
-Run any javascript in the current directory when it is updated in Windows
-Powershell:
+Run any JavaScript in the current directory when it is updated in Windows
+PowerShell:
 
 ```
 > filewatcher *.js "node %FILENAME%"
@@ -65,9 +65,9 @@ In Linux/macOS:
 $ filewatcher *.js 'node $FILENAME'
 ```
 
-Place filenames or filenames in quotes to use ruby filename globbing instead
+Place filenames in quotes to use Ruby filename globbing instead
 of shell filename globbing. This will make filewatcher look for files in
-subdirectories too. To watch all javascript files in subdirectories in Windows:
+subdirectories too. To watch all JavaScript files in subdirectories in Windows:
 
 ```
 > filewatcher "**/*.js" "node %FILENAME%"
@@ -80,15 +80,15 @@ $ filewatcher '**/*.js' 'node $FILENAME'
 ```
 
 Try to run the updated file as a script when it is updated by using the
---exec/-e option. Works with files with file extensions that looks like a
-python, ruby, perl, php, javascript or awk script.
+`--exec/-e` option. Works with files with file extensions that looks like a
+Python, Ruby, Perl, PHP, JavaScript or AWK script.
 
 ```
 $ filewatcher -e *.rb
 ```
 
 Print a list of all files matching \*.css first and then output the filename
-when a file is beeing updated by using the --list/-l option:
+when a file is beeing updated by using the `--list/-l` option:
 
 ```
 $ filewatcher -l '**/*.css' 'echo file: $FILENAME'
@@ -103,13 +103,16 @@ $ filewatcher "src test" "ruby test/test_suite.rb"
 
 ## Restart long running commands
 
-The `--restart` option kills the command if it's still running when a filesystem change happens. Can be used to restart locally running webservers on updates, or kill long running tests and restart on updates. This option often makes filewatcher faster in general. To not wait for tests to finish:
+The `--restart/-r` option kills the command if it's still running when
+a filesystem change happens. Can be used to restart locally running webservers
+on updates, or kill long running tests and restart on updates. This option
+often makes filewatcher faster in general. To not wait for tests to finish:
 
 ```
 $ filewatcher --restart "**/*.rb" "rake test"
 ```
 
-The `--immediate` option starts the command on startup without waiting for filesystem updates. To start a webserver and have it automatically restart when html files are updated:
+The `--immediate/-I` option starts the command on startup without waiting for filesystem updates. To start a webserver and have it automatically restart when html files are updated:
 
 ```
 $ filewatcher --restart --immediate "**/*.html" "python -m SimpleHTTPServer"
@@ -117,7 +120,7 @@ $ filewatcher --restart --immediate "**/*.html" "python -m SimpleHTTPServer"
 
 ## Daemonizing filewatcher process
 
-The `--daemon` option starts filewatcher in the background as system daemon, so filewatcher will not be terminated by `Ctrl+C`, for example.
+The `--daemon/-D` option starts filewatcher in the background as system daemon, so filewatcher will not be terminated by `Ctrl+C`, for example.
 
 ## Available enviroment variables
 

--- a/bin/filewatcher
+++ b/bin/filewatcher
@@ -29,6 +29,8 @@ EOS
 
   opt :immediate, 'Immediately execute a command',
       short: 'I', type: :boolean, default: false
+  opt :every, 'Run command for every updated file in one filesystem check',
+      short: 'E', type: :boolean, default: false
   opt :daemon, 'Run in the background as system daemon',
       short: 'D', type: :boolean, default: false
   opt :restart, 'Restart process when filesystem is updated',
@@ -56,27 +58,22 @@ end
 files << ARGV[0] if ARGV.length == 1
 
 def split_files_void_escaped_whitespace(files)
-  splitted_filenames = []
-  files.each do |name|
-    name = name.gsub(/\\\s/, '_ESCAPED_WHITESPACE_')
-    splitted_filenames << name.split(/\s/)
-  end
-  files = splitted_filenames.flatten.uniq
-  splitted_filenames = []
-  files.each do |name|
-    splitted_filenames << name.gsub('_ESCAPED_WHITESPACE_', '\ ')
-  end
-  splitted_filenames
+  files
+    .map { |name| name.gsub(/\\\s/, '_ESCAPED_WHITESPACE_').split(/\s/) }
+    .flatten
+    .uniq
+    .map { |name| name.gsub('_ESCAPED_WHITESPACE_', '\ ') }
 end
 
 files = split_files_void_escaped_whitespace(files)
 child_pid = nil
 
 def restart(child_pid, env, cmd)
+  raise Errno::ESRCH unless child_pid
   Process.kill(9, child_pid)
   Process.wait(child_pid)
 rescue Errno::ESRCH
-  # already killed
+  nil # already killed
 ensure
   Process.spawn(env, cmd)
 end
@@ -85,6 +82,37 @@ if options[:exclude] != ''
   options[:exclude] = split_files_void_escaped_whitespace(
     options[:exclude].split(' ')
   )
+end
+
+def build_env(filename, event)
+  path = Pathname.new(filename)
+  ENV['FILEPATH'] = path.realpath.to_s if event != :deleted
+  {
+    'FILENAME' => filename,
+    'BASENAME' => path.basename.to_s,
+    'EVENT' => event.to_s,
+    'DIRNAME' => path.parent.realpath.to_s,
+    'ABSOLUTE_FILENAME' => path.realpath.to_s,
+    'RELATIVE_FILENAME' => File.join('.', path)
+  }
+end
+
+## Define runners for `--exec` option
+class Filewatcher
+  @runners = {
+    python: %w(py),
+    node: %w(js),
+    ruby: %w(rb),
+    perl: %w(pl),
+    awk: %w(awk),
+    php: %w(php phtml php4 php3 php5 phps)
+  }
+
+  def self.runner_command(filename)
+    ext = File.extname(filename).delete('.')
+    runner = @runners.find { |_cmd, exts| exts.include? ext }
+    "env #{runner.first} #{filename}" if runner
+  end
 end
 
 begin
@@ -99,47 +127,21 @@ begin
 
   Process.daemon(true, true) if options[:daemon]
 
-  runners = {
-    python: %w(py),
-    node: %w(js),
-    ruby: %w(rb),
-    perl: %w(pl),
-    awk: %w(awk),
-    php: %w(php phtml php4 php3 php5 phps)
-  }
+  fw.watch(options[:interval]) do |changes|
+    changes = changes.first(1) unless options[:every]
+    changes.each do |filename, event|
+      cmd =
+        if options[:exec] && File.exist?(filename)
+          Filewatcher.runner_command(filename)
+        elsif ARGV.length > 1
+          ARGV[-1]
+        end
 
-  fw.watch(options[:interval]) do |filename, event|
-    cmd = nil
-    if options[:exec] && File.exist?(filename)
-      ext = File.extname(filename).delete('.')
-      runner = runners.find { |_cmd, exts| exts.include? ext }
-      cmd = "env #{runner.first} #{filename}" if runner
-    elsif ARGV.length > 1
-      cmd = ARGV[-1]
-    end
+      next puts "file #{event}: #{filename}" unless cmd
 
-    if cmd
-      path = Pathname.new(filename)
-      env = {
-        'FILENAME' => filename,
-        'BASENAME' => path.basename.to_s,
-        'FILEDIR' => path.parent.realpath.to_s, # Deprecated
-        'FSEVENT' => event.to_s, # Deprecated,
-        'EVENT' => event.to_s,
-        'DIRNAME' => path.parent.realpath.to_s,
-        'ABSOLUTE_FILENAME' => path.realpath.to_s,
-        'RELATIVE_FILENAME' => File.join('.', path)
-      }
-
-      ENV['FILEPATH'] = path.realpath.to_s if event != :deleted
-
+      env = build_env(filename, event)
       if options[:restart]
-        child_pid =
-          if child_pid.nil?
-            Process.spawn(env, cmd)
-          else
-            restart(child_pid, env, cmd)
-          end
+        child_pid = restart(child_pid, env, cmd)
       else
         begin
           Process.spawn(env, cmd)
@@ -148,9 +150,6 @@ begin
           exit(0)
         end
       end
-
-    else
-      puts "file #{event}: #{filename}"
     end
   end
 rescue SystemExit, Interrupt

--- a/bin/filewatcher
+++ b/bin/filewatcher
@@ -42,8 +42,10 @@ EOS
       type: :string, default: '*'
   opt :exclude, 'Exclude file(s) matching',
       type: :string, default: ''
-  opt :interval, 'Interval to scan filesystem.',
+  opt :interval, 'Interval to scan filesystem',
       short: 'i', type: :float, default: 0.5
+  opt :delay, 'Delay before a command will be executed again',
+      short: 'd', type: :float, default: 0.0
   opt :spinner, 'Show an ascii spinner',
       short: 's', type: :boolean, default: false
 end

--- a/lib/filewatcher.rb
+++ b/lib/filewatcher.rb
@@ -22,6 +22,7 @@ class FileWatcher
     @immediate = options[:immediate]
     @show_spinner = options[:spinner]
     @interval = options[:interval]
+    @delay = options[:delay].to_f
   end
 
   def watch(sleep = 0.5, &on_update)
@@ -45,6 +46,7 @@ class FileWatcher
       # changes twice if @keep_watching has just been set to false
       yield @changes if @changes.any?
       @changes.clear
+      Kernel.sleep @delay if @delay > 0
     end
     @end_snapshot = mtime_snapshot
     finalize(&on_update)

--- a/lib/filewatcher.rb
+++ b/lib/filewatcher.rb
@@ -30,7 +30,7 @@ class FileWatcher
     @sleep = @interval if @interval && @interval > 0
     @stored_update = on_update
     @keep_watching = true
-    yield '', '' if @immediate
+    yield({ '' => '' }) if @immediate
     while @keep_watching
       @end_snapshot = mtime_snapshot if @pausing
       while @keep_watching && @pausing
@@ -41,10 +41,10 @@ class FileWatcher
         update_spinner('Watching')
         Kernel.sleep @sleep
       end
-      # test and null @updated_file to prevent yielding the last
-      # file twice if @keep_watching has just been set to false
-      yield @updated_file, @event if @updated_file
-      @updated_file = nil
+      # test and clear @changes to prevent yielding the last
+      # changes twice if @keep_watching has just been set to false
+      yield @changes if @changes.any?
+      @changes.clear
     end
     @end_snapshot = mtime_snapshot
     finalize(&on_update)
@@ -82,7 +82,7 @@ class FileWatcher
     snapshot = @end_snapshot ? @end_snapshot : mtime_snapshot
     while filesystem_updated?(snapshot)
       update_spinner('Finalizing')
-      on_update.call(@updated_file, @event)
+      on_update.call(@changes)
     end
     @end_snapshot = nil
   end
@@ -114,26 +114,24 @@ class FileWatcher
   end
 
   def filesystem_updated?(snapshot_to_use = nil)
-    snapshot = snapshot_to_use ? snapshot_to_use : mtime_snapshot
+    snapshot = snapshot_to_use || mtime_snapshot
     forward_changes = snapshot.to_a - @last_snapshot.to_a
+    @changes = {}
 
     forward_changes.each do |file, mtime|
-      @updated_file = file
-      @event = @last_snapshot.fetch(@updated_file, false) ? :updated : :created
+      event = @last_snapshot.fetch(file, false) ? :updated : :created
+      @changes[file] = event
       @last_snapshot[file] = mtime
-      return true
     end
 
     backward_changes = @last_snapshot.to_a - snapshot.to_a
     forward_names = forward_changes.map(&:first)
     backward_changes.reject! { |f, _m| forward_names.include?(f) }
     backward_changes.each do |file, _mtime|
-      @updated_file = file
+      @changes[file] = :deleted
       @last_snapshot.delete(file)
-      @event = :deleted
-      return true
     end
-    false
+    @changes.any?
   end
 
   def last_found_filenames

--- a/test/test_filewatcher.rb
+++ b/test/test_filewatcher.rb
@@ -141,7 +141,7 @@ describe FileWatcher do
     filewatcher.filesystem_updated?.should.be.false
     processed = []
     Thread.new(filewatcher, processed) do
-      filewatcher.watch(0.1) { |f, _e| processed << f }
+      filewatcher.watch(0.1) { |changes| processed.concat(changes.keys) }
     end
     sleep 0.2 # thread needs a chance to start
     filewatcher.pause
@@ -168,7 +168,7 @@ describe FileWatcher do
     filewatcher.filesystem_updated?.should.be.false
     processed = []
     thread = Thread.new(filewatcher, processed) do
-      filewatcher.watch(0.1) { |f, _e| processed << f }
+      filewatcher.watch(0.1) { |changes| processed.concat(changes.keys) }
     end
     sleep 0.2 # thread needs a chance to start
     filewatcher.stop

--- a/test/test_filewatcher.rb
+++ b/test/test_filewatcher.rb
@@ -110,6 +110,24 @@ describe FileWatcher do
     filewatcher.filesystem_updated?.should.be.true
   end
 
+  it 'should not detect file updates in delay' do
+    filename = 'test/fixtures/file1.txt'
+    open(filename, 'w') { |f| f.puts 'content1' }
+    filewatcher = FileWatcher.new(['test/fixtures'], interval: 0.1, delay: 0.5)
+    processed = []
+    thread = Thread.new(filewatcher, processed) do
+      filewatcher.watch { |changes| processed.concat(changes.keys) }
+    end
+    sleep 0.2 # thread needs a chance to start
+    processed.size.should.be.zero # update block should not have been called
+    open(filename, 'w') { |f| f.puts 'content3' }
+    sleep 0.2 # Give filewatcher time to respond
+    processed.size.should.equal 1 # update block should have been called
+    open(filename, 'w') { |f| f.puts 'content2' }
+    processed.size.should.equal 1 # update block should not have been called
+    thread.exit
+  end
+
   it 'should detect new files in subfolders' do
     FileUtils.mkdir_p subfolder
 


### PR DESCRIPTION
Also:

*   Filewatcher lib now returns `changes` Hash(filename => event) into `watch` block.

*   Many refactorings, less RuboCop warnings.

*   Fix typos in README