### PR TITLE
Improvements for `--delay` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,13 @@ Needs Ruby and RubyGems:
 $ [sudo] gem install filewatcher
 ```
 
+## Usage warning
+
+JRuby doesn't provide milliseconds of `File.mtime`, as MRI does.
+So be careful with `--interval` and `--delay` less than 1 second.
+
+[Issue](https://github.com/jruby/jruby/issues/4520)).
+
 ## Command line utility
 
 Filewatcher scans the filesystem and execute a shell command when files are

--- a/lib/filewatcher.rb
+++ b/lib/filewatcher.rb
@@ -44,9 +44,12 @@ class FileWatcher
       end
       # test and clear @changes to prevent yielding the last
       # changes twice if @keep_watching has just been set to false
-      yield @changes if @changes.any?
-      @changes.clear
+      thread = Thread.new do
+        yield @changes if @changes.any?
+        @changes.clear
+      end
       Kernel.sleep @delay if @delay > 0
+      thread.join
     end
     @end_snapshot = mtime_snapshot
     finalize(&on_update)

--- a/test/test_filewatcher.rb
+++ b/test/test_filewatcher.rb
@@ -113,15 +113,17 @@ describe FileWatcher do
   it 'should not detect file updates in delay' do
     filename = 'test/fixtures/file1.txt'
     open(filename, 'w') { |f| f.puts 'content1' }
-    filewatcher = FileWatcher.new(['test/fixtures'], interval: 0.1, delay: 0.5)
+    ## Bigger time is HACK for JRuby, that doesn't count milliseconds:
+    ## https://github.com/jruby/jruby/issues/4520
+    filewatcher = FileWatcher.new(['test/fixtures'], interval: 1, delay: 3)
     processed = []
     thread = Thread.new(filewatcher, processed) do
       filewatcher.watch { |changes| processed.concat(changes.keys) }
     end
-    sleep 0.2 # thread needs a chance to start
+    sleep 2 # thread needs a chance to start
     processed.size.should.be.zero # update block should not have been called
     open(filename, 'w') { |f| f.puts 'content3' }
-    sleep 0.2 # Give filewatcher time to respond
+    sleep 2 # Give filewatcher time to respond
     processed.size.should.equal 1 # update block should have been called
     open(filename, 'w') { |f| f.puts 'content2' }
     processed.size.should.equal 1 # update block should not have been called


### PR DESCRIPTION
Prior to this, the delay was running only after executing the command.
It could be noticeable in the long run.

Now it's happening in parallel.