### PR TITLE
Fix many improtant bugs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,8 @@
 source 'https://rubygems.org'
 
 gemspec
+
+group :development do
+  gem 'bacon-custom_matchers_messages',
+      git: 'https://github.com/AlexWayfer/bacon-custom_matchers_messages.git'
+end

--- a/README.md
+++ b/README.md
@@ -189,15 +189,15 @@ Watch a list of files and directories:
 ```ruby
 require 'filewatcher'
 
-Filewatcher.new(['lib/', 'Rakefile']).watch do |filename|
-  puts "Changed #{filename}"
+Filewatcher.new(['lib/', 'Rakefile']).watch do |filename, event|
+  puts "#{filename} #{event}"
 end
 ```
 
 Watch a single directory, for changes in all files and subdirectories:
 
 ```ruby
-Filewatcher.new('lib/').watch do |filename|
+Filewatcher.new('lib/').watch do |filename, event|
   # ...
 end
 ```
@@ -205,7 +205,7 @@ end
 Notice that the previous is equivalent to the following:
 
 ```ruby
-Filewatcher.new('lib/**/*').watch do |filename|
+Filewatcher.new('lib/**/*').watch do |filename, event|
   # ...
 end
 ```
@@ -213,7 +213,7 @@ end
 Watch files and dirs in the given directory - and not in subdirectories:
 
 ```ruby
-Filewatcher.new('lib/*').watch do |filename|
+Filewatcher.new('lib/*').watch do |filename, event|
   # ...
 end
 ```
@@ -221,7 +221,7 @@ end
 Watch an absolute directory:
 
 ```ruby
-Filewatcher.new('/tmp/foo').watch do |filename|
+Filewatcher.new('/tmp/foo').watch do |filename, event|
   # ...
 end
 ```
@@ -240,7 +240,7 @@ The API takes some of the same options as the command line interface. To watch a
 
 ```ruby
 Filewatcher.new('**/*.*', exclude: '**/*.rb', spinner: true, interval: 0.1)
-  .watch do |filename|
+  .watch do |filename, event|
     puts filename
   end
 ```
@@ -292,7 +292,7 @@ If basename, relative filename or absolute filename is necessary use the standar
 ```ruby
 require 'pathname'
 
-Filewatcher.new(['**/*.*']).watch do |filename|
+Filewatcher.new(['**/*.*']).watch do |filename, event|
   path = Pathname.new(filename)
   puys "Basename         : #{path.basename}"
   puts "Relative filename: #{File.join('.', path)}"

--- a/bin/filewatcher
+++ b/bin/filewatcher
@@ -78,29 +78,25 @@ begin
 
   Process.daemon(true, true) if options[:daemon]
 
-  fw.watch do |changes|
-    changes = changes.first(1) unless options[:every]
-    changes = { '' => '' } if changes.empty? # immediate option
-    changes.each do |filename, event|
-      cmd =
-        if options[:exec] && File.exist?(filename)
-          Filewatcher::Runner.new(filename).command
-        elsif ARGV.length > 1
-          ARGV[-1]
-        end
+  fw.watch do |filename, event|
+    cmd =
+      if options[:exec] && File.exist?(filename)
+        Filewatcher::Runner.new(filename).command
+      elsif ARGV.length > 1
+        ARGV[-1]
+      end
 
-      next puts "file #{event}: #{filename}" unless cmd
+    next puts "file #{event}: #{filename}" unless cmd
 
-      env = Filewatcher::Env.new(filename, event).to_h
-      if options[:restart]
-        child_pid = restart(child_pid, env, cmd)
-      else
-        begin
-          Process.spawn(env, cmd)
-          Process.wait
-        rescue SystemExit, Interrupt
-          exit(0)
-        end
+    env = Filewatcher::Env.new(filename, event).to_h
+    if options[:restart]
+      child_pid = restart(child_pid, env, cmd)
+    else
+      begin
+        Process.spawn(env, cmd)
+        Process.wait
+      rescue SystemExit, Interrupt
+        exit(0)
       end
     end
   end

--- a/lib/filewatcher/cycles.rb
+++ b/lib/filewatcher/cycles.rb
@@ -33,9 +33,12 @@ class Filewatcher
       end
     end
 
-    def trigger_changes
+    def trigger_changes(on_update = @on_update)
       thread = Thread.new do
-        @on_update.call(@changes) if @changes.any?
+        changes = @every ? @changes : @changes.first(1)
+        changes.each do |filename, event|
+          on_update.call(filename, event)
+        end
         @changes.clear
       end
       thread.join


### PR DESCRIPTION
Now `Filewatcher#watch` calling received block with `filename, event` arguments
instead of `changes` (`Hash`).

Fix the bug with permanent `deleted` event.

Add `every` option for `Filewatcher` object (Ruby API).

Improve quality of tests.

Resolve #75.