### PR TITLE
Only trap supported signals

### DIFF
--- a/lib/filewatcher.rb
+++ b/lib/filewatcher.rb
@@ -29,7 +29,7 @@ class Filewatcher
   end
 
   def watch(&on_update)
-    %w[HUP INT TERM].each { |signal| trap(signal) { exit } }
+    %w[HUP INT TERM].each { |signal| trap(signal) { exit } if Signal.list.include? signal }
     @on_update = on_update
     @keep_watching = true
     yield('', '') if @immediate

--- a/lib/filewatcher.rb
+++ b/lib/filewatcher.rb
@@ -29,7 +29,9 @@ class Filewatcher
   end
 
   def watch(&on_update)
-    %w[HUP INT TERM].each { |signal| trap(signal) { exit } if Signal.list.include? signal }
+    ## The set of available signals depends on the OS
+    ## Windows doesn't support `HUP` signal, for example
+    (%w[HUP INT TERM] & Signal.list.keys).each { |signal| trap(signal) { exit } }
     @on_update = on_update
     @keep_watching = true
     yield('', '') if @immediate


### PR DESCRIPTION
Hello,

currently, filewatcher does not run under Windows and throws `lib/filewatcher.rb:32:in 'trap': unsupported signal SIGHUP (ArgumentError)` as Ruby under Windows does not support SIGHUP.

I've added a check that compares the signal to be trapped with the contents of `Signal.list` that contains the supported signals of the respective Ruby implementation. This should also prevent similar errors on other OS / implementations, although I have only tested Windows and Linux.

Best regards,
Mathias