### PR TITLE
Fix --restart

### DIFF
--- a/bin/filewatcher
+++ b/bin/filewatcher
@@ -56,7 +56,7 @@ def restart(child_pid, env, cmd)
 rescue Errno::ESRCH
   nil # already killed
 ensure
-  Process.spawn(env, cmd)
+  return Process.spawn(env, cmd)
 end
 
 if options[:exclude].to_s != ''


### PR DESCRIPTION
I've always had trouble with the `--restart` flag. I want it to restart web servers on file changes, but I always seem to get an _address in use_ error no matter what I do.

Steps to reproduce

```
$ touch a
$ filewatcher -I --restart a 'python -m SimpleHTTPServer'
Serving HTTP on 0.0.0.0 port 8000 ...
```

Then in another window, run `touch a` to make filewatcher restart the server. I get something like this.
```
Traceback (most recent call last):
  File "/Users/lthomas1/.asdf/installs/python/2.7/lib/python2.7/runpy.py", line 162, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/Users/lthomas1/.asdf/installs/python/2.7/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/Users/lthomas1/.asdf/installs/python/2.7/lib/python2.7/SimpleHTTPServer.py", line 218, in <module>
    test()
  File "/Users/lthomas1/.asdf/installs/python/2.7/lib/python2.7/SimpleHTTPServer.py", line 214, in test
    BaseHTTPServer.test(HandlerClass, ServerClass)
  File "/Users/lthomas1/.asdf/installs/python/2.7/lib/python2.7/BaseHTTPServer.py", line 592, in test
    httpd = ServerClass(server_address, HandlerClass)
  File "/Users/lthomas1/.asdf/installs/python/2.7/lib/python2.7/SocketServer.py", line 408, in __init__
    self.server_bind()
  File "/Users/lthomas1/.asdf/installs/python/2.7/lib/python2.7/BaseHTTPServer.py", line 108, in server_bind
    SocketServer.TCPServer.server_bind(self)
  File "/Users/lthomas1/.asdf/installs/python/2.7/lib/python2.7/SocketServer.py", line 419, in server_bind
    self.socket.bind(self.server_address)
  File "/Users/lthomas1/.asdf/installs/python/2.7/lib/python2.7/socket.py", line 222, in meth
    return getattr(self._sock,name)(*args)
socket.error: [Errno 48] Address already in use
```

The new process we're starting isn't able to listen to the port because the old process is still hanging around.

I started digging around and I noticed the variable `child_pid` is always `nil`, ever after filewatcher cycles the process. _I think_ we need to add an explicit return in the `ensure` block to alter the return value of the `restart` command. I did some googling and this blog post seems to confirm that suspicion http://blog.leshill.org/blog/2009/11/17/ensure-with-explicit-return.html.

