### PR TITLE
Replace `Trollop` with `Optimist`

### DIFF
--- a/bin/filewatcher
+++ b/bin/filewatcher
@@ -5,9 +5,10 @@ require_relative '../lib/filewatcher'
 require_relative '../lib/filewatcher/env'
 require_relative '../lib/filewatcher/runner'
 require_relative '../lib/filewatcher/version'
-require 'trollop'
 
-options = Trollop.options do
+require 'optimist'
+
+options = Optimist.options do
   version "filewatcher, version #{Filewatcher::VERSION} by Thomas Flemming 2016"
   banner File.read File.join(__dir__, 'banner.txt')
 
@@ -32,7 +33,7 @@ options = Trollop.options do
       short: 's', type: :boolean, default: false
 end
 
-Trollop.die Trollop.educate if ARGV.empty?
+Optimist.die Optimist.educate if ARGV.empty?
 
 files = ARGV[0..-2]
 

--- a/filewatcher.gemspec
+++ b/filewatcher.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.licenses = ['MIT']
 
   s.add_development_dependency 'bacon', '~> 1.2'
-  s.add_runtime_dependency     'trollop', '~> 2.1', '>= 2.1.2'
+  s.add_runtime_dependency     'optimist', '~> 3.0'
   s.add_development_dependency 'rake', '~> 12.0'
   s.add_development_dependency 'rubocop', '~> 0.57'
 end


### PR DESCRIPTION
```
Post-install message from trollop:
!    The 'trollop' gem has been deprecated and has been replaced by 'optimist'.
!    See: https://rubygems.org/gems/optimist
!    And: https://github.com/ManageIQ/optimist
```

Resolve #92 