### PR TITLE
Fix --restart option

### DIFF
--- a/bin/filewatcher
+++ b/bin/filewatcher
@@ -52,6 +52,7 @@ child_pid = nil
 
 def restart(pid, env, cmd)
   begin
+    raise Errno::ESRCH unless pid
     Process.kill(9, pid)
     Process.wait(pid)
   rescue Errno::ESRCH

--- a/test/test_filewatcher.rb
+++ b/test/test_filewatcher.rb
@@ -339,5 +339,16 @@ describe Filewatcher do
 
       File.exist?(ShellWatchRun::ENV_FILE).should.be.false
     end
+
+    it 'should work with restart option' do
+      swr = ShellWatchRun.new(
+        options: { restart: true }
+      )
+
+      swr.run
+
+      File.exist?(ShellWatchRun::ENV_FILE).should.be.true
+      File.read(ShellWatchRun::ENV_FILE).should.equal 'watched'
+    end
   end
 end


### PR DESCRIPTION
Steps to reproduce:

```
➤ touch a                                                                                                                                                                                                                                                                                                                                                                            
➤ filewatcher --restart --immediate "a" 'echo "hello"'                                                                                                                                                                                                                                                                                                                               
Traceback (most recent call last):
	6: from /Users/acid/.asdf/installs/ruby/2.5.1/bin/filewatcher:23:in `<main>'
	5: from /Users/acid/.asdf/installs/ruby/2.5.1/bin/filewatcher:23:in `load'
	4: from /Users/acid/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/filewatcher-1.1.0/bin/filewatcher:81:in `<top (required)>'
	3: from /Users/acid/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/filewatcher-1.1.0/lib/filewatcher.rb:40:in `watch'
	2: from /Users/acid/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/filewatcher-1.1.0/bin/filewatcher:93:in `block in <top (required)>'
	1: from /Users/acid/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/filewatcher-1.1.0/bin/filewatcher:55:in `restart'
/Users/acid/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/filewatcher-1.1.0/bin/filewatcher:55:in `kill': no implicit conversion from nil to integer (TypeError)
```

I re-introduced the safeguard for the initial state which was omitted in this commit https://github.com/thomasfl/filewatcher/commit/6c4a7ce287b2377aaf34bfc3cf1f8fd03b3acb11